### PR TITLE
Dimming View tap recogniser not firing drawer position

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -583,10 +583,7 @@ open class PulleyViewController: UIViewController, UIScrollViewDelegate, PulleyP
     {
         if gestureRecognizer == dimmingViewTapRecognizer
         {
-            if gestureRecognizer.state == .began
-            {
-                self.setDrawerPosition(position: .collapsed, animated: true)
-            }
+            self.setDrawerPosition(position: .collapsed, animated: true)
         }
     }
     


### PR DESCRIPTION
I noticed that the dimming view tap recogniser is not firing the drawer position change. Not sure why checking for the state in this case but if you want to keep it than check for .ended instead of .began.