### PR TITLE
Updated view controller containment calls according to Apple’s Documentation

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -117,6 +117,7 @@ open class PulleyViewController: UIViewController, UIScrollViewDelegate, PulleyP
             }
             
             controller.view.removeFromSuperview()
+            controller.willMove(toParentViewController: nil)
             controller.removeFromParentViewController()
         }
         
@@ -130,6 +131,7 @@ open class PulleyViewController: UIViewController, UIScrollViewDelegate, PulleyP
             
             self.primaryContentContainer.addSubview(controller.view)
             self.addChildViewController(controller)
+            controller.didMove(toParentViewController: self)
             
             if self.isViewLoaded
             {
@@ -148,6 +150,7 @@ open class PulleyViewController: UIViewController, UIScrollViewDelegate, PulleyP
             }
             
             controller.view.removeFromSuperview()
+            controller.willMove(toParentViewController: nil)
             controller.removeFromParentViewController()
         }
         
@@ -161,6 +164,7 @@ open class PulleyViewController: UIViewController, UIScrollViewDelegate, PulleyP
             
             self.drawerContentContainer.addSubview(controller.view)
             self.addChildViewController(controller)
+            controller.didMove(toParentViewController: self)
             
             if self.isViewLoaded
             {


### PR DESCRIPTION
Hi,

first of all: Thanks for the library as it's helping us really well :)

While implementing it I noticed that some methods (which we need) were not called as expected and noted in Apple's Documentation. A view controller should always be notified when it was added to or removed from a container view controller.

This patch contains the required changes according to the docs. Specifically these two parts:

> If you are implementing your own container view controller, it must call the willMove(toParentViewController:) method of the child view controller before calling the removeFromParentViewController() method, passing in a parent value of nil.

> When your custom container calls the addChildViewController(_:) method, it automatically calls the willMove(toParentViewController:) method of the view controller to be added as a child before adding it.

https://developer.apple.com/reference/uikit/uiviewcontroller/1621381-willmove

> If you are implementing your own container view controller, it must call the didMove(toParentViewController:) method of the child view controller after the transition to the new controller is complete or, if there is no transition, immediately after calling the addChildViewController(_:) method.

> The removeFromParentViewController() method automatically calls the didMove(toParentViewController:) method of the child view controller after it removes the child.

https://developer.apple.com/reference/uikit/uiviewcontroller/1621405-didmove

