### PR TITLE
Allow container view to be embedded in navVC

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -416,12 +416,12 @@ open class PulleyViewController: UIViewController {
             {
                 if child.view == primaryContentContainerView.subviews.first
                 {
-                    primaryContentViewController = child
+                    primaryContentViewController = trueChildViewController(for: child)
                 }
-                
+
                 if child.view == drawerContentContainerView.subviews.first
                 {
-                    drawerContentViewController = child
+                    drawerContentViewController = trueChildViewController(for: child)
                 }
             }
             
@@ -432,6 +432,14 @@ open class PulleyViewController: UIViewController {
         
         scrollViewDidScroll(drawerScrollView)
     }
+
+    private func trueChildViewController(for viewController: UIViewController) -> UIViewController {
+        guard let embeddedVC = viewController.childViewControllers.first else {
+            return viewController
+        }
+        return embeddedVC
+    }
+
     
     override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)


### PR DESCRIPTION
When container view's parent controller is NavigationController, the "main" viewController is not connected properly and for example loses the delegate callbacks.

This will fix that by checking, if child has children, it will use the first child of the child instead of just the child who might actually be just container for more children.