### PR TITLE
Add visibleDrawerHeight property to PulleyViewController

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -190,6 +190,15 @@ open class PulleyViewController: UIViewController {
             setNeedsStatusBarAppearanceUpdate()
         }
     }
+
+    // The visible height of the drawer. Useful for adjusting the display of content in the main content view.
+    public var visibleDrawerHeight: CGFloat {
+        if drawerPosition == .closed {
+            return 0.0
+        } else {
+            return drawerScrollView.bounds.height
+        }
+    }
     
     /// The background visual effect layer for the drawer. By default this is the extraLight effect. You can change this if you want, or assign nil to remove it.
     public var drawerBackgroundVisualEffectView: UIVisualEffectView? = UIVisualEffectView(effect: UIBlurEffect(style: .extraLight)) {


### PR DESCRIPTION
This Pull Request adds a new property to `PulleyViewController` that returns the visible height of the drawer. This is handy for performing layout in the main content view controller that fits around the drawer. 