### PR TITLE
Add allowsUserDrawerPositionChange property to PulleyViewController

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -278,6 +278,13 @@ open class PulleyViewController: UIViewController {
             initialDrawerPosition = PulleyPosition.positionFor(string: initialDrawerPositionFromIB)
         }
     }
+
+    /// Whether the drawer's position can be changed by the user. If set to `false`, the only way to move the drawer is programmatically. Defaults to `true`.
+    public var allowsUserDrawerPositionChange: Bool = true {
+        didSet {
+            enforceCanScrollDrawer()
+        }
+    }
     
     /// The drawer positions supported by the drawer
     fileprivate var supportedDrawerPositions: [PulleyPosition] = PulleyPosition.all {
@@ -307,7 +314,7 @@ open class PulleyViewController: UIViewController {
                 setDrawerPosition(position: lowestDrawerState, animated: false)
             }
             
-            drawerScrollView.isScrollEnabled = supportedDrawerPositions.count > 1
+            enforceCanScrollDrawer()
         }
     }
     
@@ -432,9 +439,9 @@ open class PulleyViewController: UIViewController {
             
             assert(primaryContentViewController != nil && drawerContentViewController != nil, "Container views must contain an embedded view controller.")
         }
-        
+
+        enforceCanScrollDrawer()
         setDrawerPosition(position: initialDrawerPosition, animated: false)
-        
         scrollViewDidScroll(drawerScrollView)
     }
     
@@ -503,6 +510,15 @@ open class PulleyViewController: UIViewController {
     override open func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
+    }
+
+    // MARK: Private State Updates
+
+    private func enforceCanScrollDrawer() {
+        guard isViewLoaded else {
+            return
+        }
+        drawerScrollView.isScrollEnabled = allowsUserDrawerPositionChange && supportedDrawerPositions.count > 1
     }
     
     // MARK: Configuration Updates


### PR DESCRIPTION
This Pull Request adds the `allowsUserDrawerPositionChange` property to `PulleyViewController`, which essentially has the effect of disabling the `drawerScrollView`'s ability to scroll.

While we ideally want to allow the user to change the drawer's position at will, in some cases that isn't desirable. In our case, we're building a drag-and-drop interaction from the drawer to the main content view controller. While the drag is in progress, we collapse the drawer and turn it into an area the user can drop onto to cancel the drag. During this operation, we don't want the user to be able to manipulate the drawer. 

![simulator screen shot 22 may 2017 11 33 32](https://cloud.githubusercontent.com/assets/514900/26301836/a51b6f66-3ee2-11e7-9b03-2c57fd81b96c.png)
