### PR TITLE
support nested PulleyViewControllers

### DIFF
--- a/Pulley.xcodeproj/project.pbxproj
+++ b/Pulley.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		C6DF73DD1D2DE2B500735EBC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C6DF73DB1D2DE2B500735EBC /* LaunchScreen.storyboard */; };
 		C6DF73EA1D2DFE7F00735EBC /* DrawerContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DF73E91D2DFE7F00735EBC /* DrawerContentViewController.swift */; };
 		C6DF73EC1D2E027500735EBC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C6DF73EB1D2E027500735EBC /* Main.storyboard */; };
+		F7D270C11F3218E30035D833 /* PulleyViewController+Nested.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73B18BC1F31307200E29B1D /* PulleyViewController+Nested.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +61,7 @@
 		C6DF73DE1D2DE2B500735EBC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C6DF73E91D2DFE7F00735EBC /* DrawerContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerContentViewController.swift; sourceTree = "<group>"; };
 		C6DF73EB1D2E027500735EBC /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		F73B18BC1F31307200E29B1D /* PulleyViewController+Nested.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "PulleyViewController+Nested.swift"; path = "PulleyLib/PulleyViewController+Nested.swift"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -86,6 +88,7 @@
 			children = (
 				355DBF151E40EA4300671CDD /* Pulley.h */,
 				C6131BB71D305995002F27F3 /* PulleyPassthroughScrollView.swift */,
+				F73B18BC1F31307200E29B1D /* PulleyViewController+Nested.swift */,
 				C6131BB81D305995002F27F3 /* PulleyViewController.swift */,
 				355DBF161E40EA4300671CDD /* Info.plist */,
 			);
@@ -251,6 +254,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F7D270C11F3218E30035D833 /* PulleyViewController+Nested.swift in Sources */,
 				355DBF201E40EA5C00671CDD /* PulleyPassthroughScrollView.swift in Sources */,
 				355DBF211E40EA5F00671CDD /* PulleyViewController.swift in Sources */,
 			);

--- a/Pulley/DrawerContentViewController.swift
+++ b/Pulley/DrawerContentViewController.swift
@@ -15,14 +15,14 @@ class DrawerContentViewController: UIViewController {
     @IBOutlet var searchBar: UISearchBar!
     @IBOutlet var gripperView: UIView!
     
-    @IBOutlet var seperatorHeightConstraint: NSLayoutConstraint!
+    @IBOutlet var separatorHeightConstraint: NSLayoutConstraint!
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
         gripperView.layer.cornerRadius = 2.5
-        seperatorHeightConstraint.constant = 1.0 / UIScreen.main.scale
+        separatorHeightConstraint.constant = 1.0 / UIScreen.main.scale
     }
 
     override func didReceiveMemoryWarning() {

--- a/Pulley/DrawerContentViewController.swift
+++ b/Pulley/DrawerContentViewController.swift
@@ -43,7 +43,7 @@ extension DrawerContentViewController: PulleyDrawerViewControllerDelegate {
         return 264.0
     }
     
-    func supportedPositions() -> [PulleyPosition] {
+    func supportedDrawerPositions() -> [PulleyPosition] {
         return PulleyPosition.all // You can specify the drawer positions you support. This is the same as: [.open, .partiallyRevealed, .collapsed, .closed]
     }
     

--- a/Pulley/DrawerContentViewController.swift
+++ b/Pulley/DrawerContentViewController.swift
@@ -43,7 +43,7 @@ extension DrawerContentViewController: PulleyDrawerViewControllerDelegate {
         return 264.0
     }
     
-    func supportedDrawerPositions() -> [PulleyPosition] {
+    func supportedPositions() -> [PulleyPosition] {
         return PulleyPosition.all // You can specify the drawer positions you support. This is the same as: [.open, .partiallyRevealed, .collapsed, .closed]
     }
     

--- a/Pulley/Main.storyboard
+++ b/Pulley/Main.storyboard
@@ -304,7 +304,7 @@
                     <connections>
                         <outlet property="gripperView" destination="2S4-TW-Cpq" id="qvm-vW-kwY"/>
                         <outlet property="searchBar" destination="SdI-67-HKI" id="BAe-g2-quD"/>
-                        <outlet property="seperatorHeightConstraint" destination="4Qx-Tn-PkO" id="o2j-7p-e9G"/>
+                        <outlet property="separatorHeightConstraint" destination="4Qx-Tn-PkO" id="o2j-7p-e9G"/>
                         <outlet property="tableView" destination="njO-tj-uAV" id="ISn-w2-Baa"/>
                     </connections>
                 </viewController>

--- a/PulleyLib/PulleyViewController+Nested.swift
+++ b/PulleyLib/PulleyViewController+Nested.swift
@@ -24,9 +24,9 @@ extension PulleyViewController: PulleyDrawerViewControllerDelegate {
         }
     }
 
-    public func supportedPositions() -> [PulleyPosition] {
+    public func supportedDrawerPositions() -> [PulleyPosition] {
         if let drawerVCCompliant = drawerContentViewController as? PulleyDrawerViewControllerDelegate {
-            return drawerVCCompliant.supportedPositions()
+            return drawerVCCompliant.supportedDrawerPositions()
         } else {
             return PulleyPosition.all
         }

--- a/PulleyLib/PulleyViewController+Nested.swift
+++ b/PulleyLib/PulleyViewController+Nested.swift
@@ -1,0 +1,52 @@
+//
+//  PulleyViewController+Nested.swift
+//  Pulley
+//
+//  Created by Ethan Gill on 8/1/17.
+//
+
+import Foundation
+
+extension PulleyViewController: PulleyDrawerViewControllerDelegate {
+    public func collapsedDrawerHeight() -> CGFloat {
+        if let drawerVCCompliant = drawerContentViewController as? PulleyDrawerViewControllerDelegate {
+            return drawerVCCompliant.collapsedDrawerHeight()
+        } else {
+            return 68.0
+        }
+    }
+
+    public func partialRevealDrawerHeight() -> CGFloat {
+        if let drawerVCCompliant = drawerContentViewController as? PulleyDrawerViewControllerDelegate {
+            return drawerVCCompliant.partialRevealDrawerHeight()
+        } else {
+            return 264.0
+        }
+    }
+
+    public func supportedPositions() -> [PulleyPosition] {
+        if let drawerVCCompliant = drawerContentViewController as? PulleyDrawerViewControllerDelegate {
+            return drawerVCCompliant.supportedPositions()
+        } else {
+            return PulleyPosition.all
+        }
+    }
+
+    public func drawerPositionDidChange(drawer: PulleyViewController) {
+        if let drawerVCCompliant = drawerContentViewController as? PulleyDrawerViewControllerDelegate {
+            drawerVCCompliant.drawerPositionDidChange?(drawer: drawer)
+        }
+    }
+
+    public func makeUIAdjustmentsForFullscreen(progress: CGFloat) {
+        if let drawerVCCompliant = drawerContentViewController as? PulleyDrawerViewControllerDelegate {
+            drawerVCCompliant.makeUIAdjustmentsForFullscreen?(progress: progress)
+        }
+    }
+
+    public func drawerChangedDistanceFromBottom(drawer: PulleyViewController, distance: CGFloat) {
+        if let drawerVCCompliant = drawerContentViewController as? PulleyDrawerViewControllerDelegate {
+            drawerVCCompliant.drawerChangedDistanceFromBottom?(drawer: drawer, distance: distance)
+        }
+    }
+}

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -25,7 +25,7 @@ public protocol PulleyDrawerViewControllerDelegate: PulleyDelegate {
     
     func collapsedDrawerHeight() -> CGFloat
     func partialRevealDrawerHeight() -> CGFloat
-    func supportedDrawerPositions() -> [PulleyPosition]
+    func supportedPositions() -> [PulleyPosition]
 }
 
 /**
@@ -705,7 +705,7 @@ open class PulleyViewController: UIViewController {
     {
         if let drawerVCCompliant = drawerContentViewController as? PulleyDrawerViewControllerDelegate
         {
-            supportedDrawerPositions = drawerVCCompliant.supportedDrawerPositions()
+            supportedDrawerPositions = drawerVCCompliant.supportedPositions()
         }
         else
         {

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -25,7 +25,7 @@ public protocol PulleyDrawerViewControllerDelegate: PulleyDelegate {
     
     func collapsedDrawerHeight() -> CGFloat
     func partialRevealDrawerHeight() -> CGFloat
-    func supportedPositions() -> [PulleyPosition]
+    func supportedDrawerPositions() -> [PulleyPosition]
 }
 
 /**
@@ -296,27 +296,27 @@ open class PulleyViewController: UIViewController {
     }
     
     /// The drawer positions supported by the drawer
-    fileprivate var supportedDrawerPositions: [PulleyPosition] = PulleyPosition.all {
+    fileprivate var supportedPositions: [PulleyPosition] = PulleyPosition.all {
         didSet {
             
             guard self.isViewLoaded else {
                 return
             }
             
-            guard supportedDrawerPositions.count > 0 else {
-                supportedDrawerPositions = PulleyPosition.all
+            guard supportedPositions.count > 0 else {
+                supportedPositions = PulleyPosition.all
                 return
             }
             
             self.view.setNeedsLayout()
             
-            if supportedDrawerPositions.contains(drawerPosition)
+            if supportedPositions.contains(drawerPosition)
             {
                 setDrawerPosition(position: drawerPosition)
             }
             else
             {
-                let lowestDrawerState: PulleyPosition = supportedDrawerPositions.min { (pos1, pos2) -> Bool in
+                let lowestDrawerState: PulleyPosition = supportedPositions.min { (pos1, pos2) -> Bool in
                     return pos1.rawValue < pos2.rawValue
                     } ?? .collapsed
                 
@@ -481,7 +481,7 @@ open class PulleyViewController: UIViewController {
         let lowestStop = [(self.view.bounds.size.height - topInset), collapsedHeight, partialRevealHeight].min() ?? 0
         let bounceOverflowMargin: CGFloat = 20.0
         
-        if supportedDrawerPositions.contains(.open)
+        if supportedPositions.contains(.open)
         {
             // Layout scrollview
             drawerScrollView.frame = CGRect(x: 0, y: topInset, width: self.view.bounds.width, height: self.view.bounds.height - topInset)
@@ -489,7 +489,7 @@ open class PulleyViewController: UIViewController {
         else
         {
             // Layout scrollview
-            let adjustedTopInset: CGFloat = supportedDrawerPositions.contains(.partiallyRevealed) ? partialRevealHeight : collapsedHeight
+            let adjustedTopInset: CGFloat = supportedPositions.contains(.partiallyRevealed) ? partialRevealHeight : collapsedHeight
             drawerScrollView.frame = CGRect(x: 0, y: self.view.bounds.height - adjustedTopInset, width: self.view.bounds.width, height: adjustedTopInset)
         }
         
@@ -527,7 +527,7 @@ open class PulleyViewController: UIViewController {
         guard isViewLoaded else {
             return
         }
-        drawerScrollView.isScrollEnabled = allowsUserDrawerPositionChange && supportedDrawerPositions.count > 1
+        drawerScrollView.isScrollEnabled = allowsUserDrawerPositionChange && supportedPositions.count > 1
     }
     
     // MARK: Configuration Updates
@@ -540,7 +540,7 @@ open class PulleyViewController: UIViewController {
      - parameter completion: A block object to be executed when the animation sequence ends. The Bool indicates whether or not the animations actually finished before the completion handler was called. (Default: nil)
      */
     public func setDrawerPosition(position: PulleyPosition, animated: Bool, completion: PulleyAnimationCompletionBlock? = nil) {
-        guard supportedDrawerPositions.contains(position) else {
+        guard supportedPositions.contains(position) else {
             
             print("PulleyViewController: You can't set the drawer position to something not supported by the current view controller contained in the drawer. If you haven't already, you may need to implement the PulleyDrawerViewControllerDelegate.")
             return
@@ -705,11 +705,11 @@ open class PulleyViewController: UIViewController {
     {
         if let drawerVCCompliant = drawerContentViewController as? PulleyDrawerViewControllerDelegate
         {
-            supportedDrawerPositions = drawerVCCompliant.supportedPositions()
+            supportedPositions = drawerVCCompliant.supportedDrawerPositions()
         }
         else
         {
-            supportedDrawerPositions = PulleyPosition.all
+            supportedPositions = PulleyPosition.all
         }
     }
     
@@ -793,17 +793,17 @@ extension PulleyViewController: UIScrollViewDelegate {
             
             var drawerStops: [CGFloat] = [CGFloat]()
             
-            if supportedDrawerPositions.contains(.open)
+            if supportedPositions.contains(.open)
             {
                 drawerStops.append((self.view.bounds.size.height - topInset))
             }
             
-            if supportedDrawerPositions.contains(.partiallyRevealed)
+            if supportedPositions.contains(.partiallyRevealed)
             {
                 drawerStops.append(partialRevealHeight)
             }
             
-            if supportedDrawerPositions.contains(.collapsed)
+            if supportedPositions.contains(.collapsed)
             {
                 drawerStops.append(collapsedHeight)
             }
@@ -822,13 +822,13 @@ extension PulleyViewController: UIScrollViewDelegate {
                 }
             }
             
-            if abs(Float(currentClosestStop - (self.view.bounds.size.height - topInset))) <= Float.ulpOfOne && supportedDrawerPositions.contains(.open)
+            if abs(Float(currentClosestStop - (self.view.bounds.size.height - topInset))) <= Float.ulpOfOne && supportedPositions.contains(.open)
             {
                 setDrawerPosition(position: .open, animated: true)
-            } else if abs(Float(currentClosestStop - collapsedHeight)) <= Float.ulpOfOne && supportedDrawerPositions.contains(.collapsed)
+            } else if abs(Float(currentClosestStop - collapsedHeight)) <= Float.ulpOfOne && supportedPositions.contains(.collapsed)
             {
                 setDrawerPosition(position: .collapsed, animated: true)
-            } else if supportedDrawerPositions.contains(.partiallyRevealed){
+            } else if supportedPositions.contains(.partiallyRevealed){
                 setDrawerPosition(position: .partiallyRevealed, animated: true)
             }
         }
@@ -860,17 +860,17 @@ extension PulleyViewController: UIScrollViewDelegate {
             
             var drawerStops: [CGFloat] = [CGFloat]()
             
-            if supportedDrawerPositions.contains(.open)
+            if supportedPositions.contains(.open)
             {
                 drawerStops.append((self.view.bounds.size.height - topInset))
             }
             
-            if supportedDrawerPositions.contains(.partiallyRevealed)
+            if supportedPositions.contains(.partiallyRevealed)
             {
                 drawerStops.append(partialRevealHeight)
             }
             
-            if supportedDrawerPositions.contains(.collapsed)
+            if supportedPositions.contains(.collapsed)
             {
                 drawerStops.append(collapsedHeight)
             }


### PR DESCRIPTION
create class extension PulleyViewController+Nested
implement all delegate methods and pass delegate function to child drawerContentViewController
implement defaults for collapsedDrawerHeight and partialRevealDrawerHeight

A while ago, there was an issue on this project discussing nesting PulleyViewControllers. In the course of implementing Pulley in a project I've been working on, I have successfully achieved this. However, it quickly becomes problematic that, when nested in a second PulleyViewController, a custom view controller cannot implement PulleyDrawerViewControllerDelegate. This pull request resolves this by having PulleyViewController implement its own delegate, and passing functions to a compliant drawerContentViewController if available.

While fixing this, Swift complained about a naming conflict between the variable `supportedDrawerPositions` and the delegate function of the same name. I have renamed the delegate function to resolve this, but the variable could be renamed instead.