### PR TITLE
Feature/use constraints

### DIFF
--- a/Pulley.xcodeproj/project.pbxproj
+++ b/Pulley.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		C6DF73DD1D2DE2B500735EBC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C6DF73DB1D2DE2B500735EBC /* LaunchScreen.storyboard */; };
 		C6DF73EA1D2DFE7F00735EBC /* DrawerContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DF73E91D2DFE7F00735EBC /* DrawerContentViewController.swift */; };
 		C6DF73EC1D2E027500735EBC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C6DF73EB1D2E027500735EBC /* Main.storyboard */; };
+		C90AFDF51F4CE002003D1EA3 /* UIView+constrainToParent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90AFDF41F4CE002003D1EA3 /* UIView+constrainToParent.swift */; };
 		F7D270C11F3218E30035D833 /* PulleyViewController+Nested.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73B18BC1F31307200E29B1D /* PulleyViewController+Nested.swift */; };
 /* End PBXBuildFile section */
 
@@ -61,6 +62,7 @@
 		C6DF73DE1D2DE2B500735EBC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C6DF73E91D2DFE7F00735EBC /* DrawerContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerContentViewController.swift; sourceTree = "<group>"; };
 		C6DF73EB1D2E027500735EBC /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		C90AFDF41F4CE002003D1EA3 /* UIView+constrainToParent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIView+constrainToParent.swift"; path = "Pulley/UIView+constrainToParent.swift"; sourceTree = "<group>"; };
 		F73B18BC1F31307200E29B1D /* PulleyViewController+Nested.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "PulleyViewController+Nested.swift"; path = "PulleyLib/PulleyViewController+Nested.swift"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -108,6 +110,7 @@
 		C6DF73C61D2DE2B500735EBC = {
 			isa = PBXGroup;
 			children = (
+				C90AFDF41F4CE002003D1EA3 /* UIView+constrainToParent.swift */,
 				C6DF73D11D2DE2B500735EBC /* Demo App */,
 				355DBF141E40EA4300671CDD /* Pulley */,
 				C6DF73D01D2DE2B500735EBC /* Products */,
@@ -257,6 +260,7 @@
 				F7D270C11F3218E30035D833 /* PulleyViewController+Nested.swift in Sources */,
 				355DBF201E40EA5C00671CDD /* PulleyPassthroughScrollView.swift in Sources */,
 				355DBF211E40EA5F00671CDD /* PulleyViewController.swift in Sources */,
+				C90AFDF51F4CE002003D1EA3 /* UIView+constrainToParent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pulley/UIView+constrainToParent.swift
+++ b/Pulley/UIView+constrainToParent.swift
@@ -3,7 +3,6 @@
 //  Pulley
 //
 //  Created by Mathew Polzin on 8/22/17.
-//  Copyright © 2017 52inc. All rights reserved.
 //
 
 import UIKit

--- a/Pulley/UIView+constrainToParent.swift
+++ b/Pulley/UIView+constrainToParent.swift
@@ -1,0 +1,22 @@
+//
+//  UIView+constrainToParent.swift
+//  Pulley
+//
+//  Created by Mathew Polzin on 8/22/17.
+//  Copyright © 2017 52inc. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+    
+    internal func constrainToParent() {
+        guard let parent = superview else { return }
+        
+        translatesAutoresizingMaskIntoConstraints = false
+        
+        parent.addConstraints(["H:|[view]|", "V:|[view]|"].flatMap({ constraintString in
+            NSLayoutConstraint.constraints(withVisualFormat: constraintString, options: [], metrics: nil, views: ["view": self])
+        }))
+    }
+}

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -137,10 +137,7 @@ open class PulleyViewController: UIViewController {
             addChildViewController(controller)
             primaryContentContainer.addSubview(controller.view)
             
-            controller.view.translatesAutoresizingMaskIntoConstraints = false
-            primaryContentContainer.addConstraints(["H:|[view]|", "V:|[view]|"].flatMap({ constraintString in
-                NSLayoutConstraint.constraints(withVisualFormat: constraintString, options: [], metrics: nil, views: ["view": controller.view])
-            }))
+            controller.view.constrainToParent()
             
             controller.didMove(toParentViewController: self)
 
@@ -174,10 +171,7 @@ open class PulleyViewController: UIViewController {
             addChildViewController(controller)
             drawerContentContainer.addSubview(controller.view)
             
-            controller.view.translatesAutoresizingMaskIntoConstraints = false
-            drawerContentContainer.addConstraints(["H:|[view]|", "V:|[view]|"].flatMap({ constraintString in
-                NSLayoutConstraint.constraints(withVisualFormat: constraintString, options: [], metrics: nil, views: ["view": controller.view])
-            }))
+            controller.view.constrainToParent()
             
             controller.didMove(toParentViewController: self)
 
@@ -431,15 +425,9 @@ open class PulleyViewController: UIViewController {
         self.view.addSubview(backgroundDimmingView)
         self.view.addSubview(drawerScrollView)
         
-        primaryContentContainer.translatesAutoresizingMaskIntoConstraints = false
-        view.addConstraints(["H:|[view]|", "V:|[view]|"].flatMap({ constraintString in
-            NSLayoutConstraint.constraints(withVisualFormat: constraintString, options: [], metrics: nil, views: ["view": primaryContentContainer])
-        }))
+        primaryContentContainer.constrainToParent()
         
-        backgroundDimmingView.translatesAutoresizingMaskIntoConstraints = false
-        view.addConstraints(["H:|[view]|", "V:|[view]|"].flatMap({ constraintString in
-            NSLayoutConstraint.constraints(withVisualFormat: constraintString, options: [], metrics: nil, views: ["view": backgroundDimmingView])
-        }))
+        backgroundDimmingView.constrainToParent()
     }
     
     override open func viewDidLoad() {
@@ -490,6 +478,8 @@ open class PulleyViewController: UIViewController {
             {
                 primaryContentContainer.addSubview(primary.view)
                 primaryContentContainer.sendSubview(toBack: primary.view)
+                
+                primary.view.constrainToParent()
             }
         }
         
@@ -500,6 +490,8 @@ open class PulleyViewController: UIViewController {
             {
                 drawerContentContainer.addSubview(drawer.view)
                 drawerContentContainer.sendSubview(toBack: drawer.view)
+                
+                drawer.view.constrainToParent()
             }
         }
         

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -135,9 +135,13 @@ open class PulleyViewController: UIViewController {
             }
 
             addChildViewController(controller)
-            controller.view.translatesAutoresizingMaskIntoConstraints = true
-            controller.view.frame = primaryContentContainer.frame
             primaryContentContainer.addSubview(controller.view)
+            
+            controller.view.translatesAutoresizingMaskIntoConstraints = false
+            primaryContentContainer.addConstraints(["H:|[view]|", "V:|[view]|"].flatMap({ constraintString in
+                NSLayoutConstraint.constraints(withVisualFormat: constraintString, options: [], metrics: nil, views: ["view": controller.view])
+            }))
+            
             controller.didMove(toParentViewController: self)
 
             if self.isViewLoaded
@@ -168,9 +172,13 @@ open class PulleyViewController: UIViewController {
             }
 
             addChildViewController(controller)
-            controller.view.translatesAutoresizingMaskIntoConstraints = true
-            controller.view.frame = drawerContentContainer.frame
             drawerContentContainer.addSubview(controller.view)
+            
+            controller.view.translatesAutoresizingMaskIntoConstraints = false
+            drawerContentContainer.addConstraints(["H:|[view]|", "V:|[view]|"].flatMap({ constraintString in
+                NSLayoutConstraint.constraints(withVisualFormat: constraintString, options: [], metrics: nil, views: ["view": controller.view])
+            }))
+            
             controller.didMove(toParentViewController: self)
 
             if self.isViewLoaded
@@ -422,6 +430,16 @@ open class PulleyViewController: UIViewController {
         self.view.addSubview(primaryContentContainer)
         self.view.addSubview(backgroundDimmingView)
         self.view.addSubview(drawerScrollView)
+        
+        primaryContentContainer.translatesAutoresizingMaskIntoConstraints = false
+        view.addConstraints(["H:|[view]|", "V:|[view]|"].flatMap({ constraintString in
+            NSLayoutConstraint.constraints(withVisualFormat: constraintString, options: [], metrics: nil, views: ["view": primaryContentContainer])
+        }))
+        
+        backgroundDimmingView.translatesAutoresizingMaskIntoConstraints = false
+        view.addConstraints(["H:|[view]|", "V:|[view]|"].flatMap({ constraintString in
+            NSLayoutConstraint.constraints(withVisualFormat: constraintString, options: [], metrics: nil, views: ["view": backgroundDimmingView])
+        }))
     }
     
     override open func viewDidLoad() {
@@ -485,11 +503,6 @@ open class PulleyViewController: UIViewController {
             }
         }
         
-        // Layout main content
-        primaryContentContainer.frame = self.view.bounds
-        backgroundDimmingView.frame = self.view.bounds
-        
-        
         // Layout container
         var collapsedHeight:CGFloat = kPulleyDefaultCollapsedHeight
         var partialRevealHeight:CGFloat = kPulleyDefaultPartialRevealHeight
@@ -530,10 +543,6 @@ open class PulleyViewController: UIViewController {
         cardMaskLayer.backgroundColor = UIColor.clear.cgColor
         drawerContentContainer.layer.mask = cardMaskLayer
         drawerShadowView.layer.shadowPath = borderPath
-        
-        // Make VC views match frames
-        primaryContentViewController?.view.frame = primaryContentContainer.bounds
-        drawerContentViewController?.view.frame = CGRect(x: drawerContentContainer.bounds.minX, y: drawerContentContainer.bounds.minY, width: drawerContentContainer.bounds.width, height: drawerContentContainer.bounds.height)
         
         setDrawerPosition(position: drawerPosition, animated: false)
     }


### PR DESCRIPTION
In using `Pulley` programmatically, I encountered broken constraint warnings that were due my views getting laid out before their size had been set to the size of the `primaryContentContainer`. Migrating certain parts of the layout code to use constraints was the easiest fix.