### PR TITLE
Fixing podspec to work with new Xcode 9 build system

### DIFF
--- a/Pulley.podspec
+++ b/Pulley.podspec
@@ -30,7 +30,7 @@ A library to provide a drawer controller that can imitate the drawer UI in iOS 1
 
   s.ios.deployment_target = '9.0'
 
-  s.source_files = 'PulleyLib/*.*'
+  s.source_files = 'PulleyLib/*.{h,swift}'
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   s.frameworks = 'UIKit'


### PR DESCRIPTION
Similar to [this](https://github.com/seedco/StackViewController/commit/0d675de9466456c1eb5292cb140121656a02a024). You can't specify wildcard identifiers for file types in podspecs, it won't compile anymore.

<img width="254" alt="pods" src="https://user-images.githubusercontent.com/716513/31191242-8da9cff6-a90b-11e7-9b9f-500725e0a974.png">

Currently the files will not show up and throws warnings, this change fixes it works.

```
ld: warning: directory not found for option '-F/Users/mergesort/Library/Developer/Xcode/DerivedData/Picks-dnkbcqxucljrxufawsyycxtltfsh/Build/Products/Debug-iphonesimulator/Pulley'
ld: framework not found Pulley
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```