### PR TITLE
Added support for TabBar in iOS10: It is now possible to add the Pull…

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -577,6 +577,14 @@ open class PulleyViewController: UIViewController {
             safeAreaTopInset = self.topLayoutGuide.length
             safeAreaBottomInset = self.bottomLayoutGuide.length
         }
+        // Bottom inset for safe area / bottomLayoutGuid
+        if #available(iOS 11, *) {
+            self.drawerScrollView.contentInsetAdjustmentBehavior = .always
+        } else {
+            self.automaticallyAdjustsScrollViewInsets = false
+            self.drawerScrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: self.bottomLayoutGuide.length, right: 0)
+            self.drawerScrollView.scrollIndicatorInsets =  UIEdgeInsets(top: 0, left: 0, bottom: self.bottomLayoutGuide.length, right: 0) // (usefull if visible..)
+        }
         
         // Layout container
         var collapsedHeight:CGFloat = kPulleyDefaultCollapsedHeight
@@ -646,7 +654,7 @@ open class PulleyViewController: UIViewController {
         }
         else
         {
-            safeAreaBottomInset = 0.0
+            safeAreaBottomInset = self.bottomLayoutGuide.length
         }
         
         return safeAreaBottomInset
@@ -1058,3 +1066,4 @@ extension PulleyViewController: UIScrollViewDelegate {
         }
     }
 }
+


### PR DESCRIPTION
Added support for TabBar in iOS10: It is now possible to add the PulleyViewController to a TabBar in iOS 10 without a visual bug for the open position. In addition, it guarantees that the UI adjustment made in the delegates will be the same for iOS 11 and iOS 10 (the bottomSafeArea will be the same if needed.