### PR TITLE
Fix issues with background dimming on iPhone X

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -1100,13 +1100,17 @@ extension PulleyViewController: UIScrollViewDelegate {
             
             let lowestStop = drawerStops.min() ?? 0
             
-            if scrollView.contentOffset.y > partialRevealHeight - lowestStop
+            if (scrollView.contentOffset.y - getBottomSafeArea()) > partialRevealHeight - lowestStop
             {
                 // Calculate percentage between partial and full reveal
                 let fullRevealHeight = (self.drawerScrollView.bounds.height)
-                
-                let progress = (scrollView.contentOffset.y - (partialRevealHeight - lowestStop)) / (fullRevealHeight - (partialRevealHeight))
-                
+                let progress: CGFloat
+                if fullRevealHeight == partialRevealHeight {
+                    progress = 1.0
+                } else {
+                    progress = (scrollView.contentOffset.y - (partialRevealHeight - lowestStop)) / (fullRevealHeight - (partialRevealHeight))
+                }
+
                 delegate?.makeUIAdjustmentsForFullscreen?(progress: progress, bottomSafeArea: getBottomSafeArea())
                 (drawerContentViewController as? PulleyDrawerViewControllerDelegate)?.makeUIAdjustmentsForFullscreen?(progress: progress, bottomSafeArea: getBottomSafeArea())
                 (primaryContentViewController as? PulleyPrimaryContentControllerDelegate)?.makeUIAdjustmentsForFullscreen?(progress: progress, bottomSafeArea: getBottomSafeArea())

--- a/PulleyLib/UIView+constrainToParent.swift
+++ b/PulleyLib/UIView+constrainToParent.swift
@@ -10,12 +10,17 @@ import UIKit
 extension UIView {
     
     internal func constrainToParent() {
+        constrainToParent(insets: UIEdgeInsets.zero)
+    }
+
+    internal func constrainToParent(insets: UIEdgeInsets) {
         guard let parent = superview else { return }
-        
+
         translatesAutoresizingMaskIntoConstraints = false
-        
-        parent.addConstraints(["H:|[view]|", "V:|[view]|"].flatMap({ constraintString in
-            NSLayoutConstraint.constraints(withVisualFormat: constraintString, options: [], metrics: nil, views: ["view": self])
+        let metrics: [String : Any] = ["left" : insets.left, "right" : insets.right, "top" : insets.top, "bottom" : insets.bottom]
+
+        parent.addConstraints(["H:|-(left)-[view]-(right)-|", "V:|-(top)-[view]-(bottom)-|"].flatMap({ constraintString in
+            NSLayoutConstraint.constraints(withVisualFormat: constraintString, options: [], metrics: metrics, views: ["view": self])
         }))
     }
 }


### PR DESCRIPTION
This pull requests fixes the issues encountered in #110: Weird stuff happens in landscape on iPhone X.

Turns out there were a couple of different issue that compounded here. 

- The first issue is that the background dimming view didn't take into account that there might be left and right safe areas that it needs to fill - it'd only dim out the top. This (and the mask on its layer)has been updated to fill the entire screen so left and right safe areas are filled (red in this screenshot): 

<img width="719" alt="screen shot 2017-11-09 at 11 21 28" src="https://user-images.githubusercontent.com/514900/32601339-94afb466-c542-11e7-991e-7777d266aef6.png">

- The second issue is that there's a bug that would cause the dimming progress to be set to `+Inf` if `partialRevealHeight == fullRevealHeight`, causing the dim to be pure black instead of the max of 0.5. This is now checked for.

- The third issue is that the "are we going towards fullscreen?" check when scrolling didn't take the bottom safe area into account, meaning smaller `partialRevealHeight` values could cause a false positive. This is now taken into account. 

**NOTE:** It's possible that line `1111` of `PulleyViewController.swift` needs to be updated to also take the bottom safe area into account. Unfortunately, I don't use fullscreen pulley drawers and I don't have the time to test it properly. Sorry! 