### PR TITLE
Add swift target

### DIFF
--- a/Pulley.podspec
+++ b/Pulley.podspec
@@ -29,6 +29,7 @@ A library to provide a drawer controller that can imitate the drawer UI in iOS 1
   s.social_media_url = 'https://twitter.com/52_inc'
 
   s.ios.deployment_target = '9.0'
+  s.swift_version = '4.0'
 
   s.source_files = 'PulleyLib/*.{h,swift}'
 


### PR DESCRIPTION
as per 1.4.0 of cocoapods .swift_version files are deprecated: [http://blog.cocoapods.org/CocoaPods-1.4.0/](http://blog.cocoapods.org/CocoaPods-1.4.0/)