### PR TITLE
Remove duplicate PulleyPosition rawValue

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -80,8 +80,8 @@ public typealias PulleyAnimationCompletionBlock = ((_ finished: Bool) -> Void)
     
     public static let collapsed = PulleyPosition(rawValue: 0)
     public static let partiallyRevealed = PulleyPosition(rawValue: 1)
-    public static let open = PulleyPosition(rawValue: 1)
-    public static let closed = PulleyPosition(rawValue: 2)
+    public static let open = PulleyPosition(rawValue: 2)
+    public static let closed = PulleyPosition(rawValue: 3)
     
     public static let all: [PulleyPosition] = [
         .collapsed,


### PR DESCRIPTION
Before version 2.4.0 (commit 4131039), each `PulleyPosition` had a distinct `rawValue`. In that commit, `PulleyPosition` was changed from an enum to a class, and in the process, the `rawValue`s were changed, causing `partiallyRevealed` and `open` to both have the same `rawValue` of `1`.

This appears to be a mistake, because the `rawValue`s are used in several places to sort `PulleyPosition`s. This commit returns `open` and `closed` to their original `rawValue`s of `2` and `3`, respectively.