### PR TITLE
Change xcconfig to pod_target_xcconfig in podspec

### DIFF
--- a/Pulley.podspec
+++ b/Pulley.podspec
@@ -36,7 +36,7 @@ A library to provide a drawer controller that can imitate the drawer UI in iOS 1
   # s.public_header_files = 'Pod/Classes/**/*.h'
   s.frameworks = 'UIKit'
 
-  s.xcconfig = {
+  s.pod_target_xcconfig = {
     'SWIFT_VERSION' => '4.0'
   }
 


### PR DESCRIPTION
Removing `SWIFT_VERSION` from `Pulley.podspec` fixes a warning that occurred during `pod install` for projects that include Pulley:

```
[!] The `MyProject [Debug]` target overrides the `SWIFT_VERSION` build setting defined in `Pods/Target Support Files/Pods-MyProject/Pods-MyProject.debug.xcconfig'. This can lead to problems with the CocoaPods installation
    - Use the `$(inherited)` flag, or
    - Remove the build settings from the target.

[!] The `MyProject [Release]` target overrides the `SWIFT_VERSION` build setting defined in `Pods/Target Support Files/Pods-MyProject/Pods-MyProject.release.xcconfig'. This can lead to problems with the CocoaPods installation
    - Use the `$(inherited)` flag, or
    - Remove the build settings from the target.
```

In fact, as mentioned by CocoaPods contributor benasher44 in [a similar issue in another project](https://github.com/CocoaLumberjack/CocoaLumberjack/issues/814#issuecomment-272704972), CocoaPods will automatically set `SWIFT_VERSION`, so it doesn’t need to be set manually.