### PR TITLE
Custom Masking

### DIFF
--- a/Pulley.xcodeproj/project.pbxproj
+++ b/Pulley.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		C6DF73DD1D2DE2B500735EBC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C6DF73DB1D2DE2B500735EBC /* LaunchScreen.storyboard */; };
 		C6DF73EA1D2DFE7F00735EBC /* DrawerContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DF73E91D2DFE7F00735EBC /* DrawerContentViewController.swift */; };
 		C6DF73EC1D2E027500735EBC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C6DF73EB1D2E027500735EBC /* Main.storyboard */; };
+		D2C07C7C2129BC8B00ED38D7 /* CustomMaskExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C07C7A2129BC0F00ED38D7 /* CustomMaskExample.swift */; };
 		E15E853120BE56B900800173 /* UIViewController+PulleyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15E853020BE56B900800173 /* UIViewController+PulleyViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -63,6 +64,7 @@
 		C6DF73DE1D2DE2B500735EBC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C6DF73E91D2DFE7F00735EBC /* DrawerContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerContentViewController.swift; sourceTree = "<group>"; };
 		C6DF73EB1D2E027500735EBC /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		D2C07C7A2129BC0F00ED38D7 /* CustomMaskExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomMaskExample.swift; sourceTree = "<group>"; };
 		E15E853020BE56B900800173 /* UIViewController+PulleyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIViewController+PulleyViewController.swift"; path = "PulleyLib/UIViewController+PulleyViewController.swift"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -134,6 +136,7 @@
 				C6DF73D41D2DE2B500735EBC /* PrimaryContentViewController.swift */,
 				C6DF73E91D2DFE7F00735EBC /* DrawerContentViewController.swift */,
 				C6131BB31D30429E002F27F3 /* PrimaryTransitionTargetViewController.swift */,
+				D2C07C7A2129BC0F00ED38D7 /* CustomMaskExample.swift */,
 				C6131BB21D303FE0002F27F3 /* Supporting Files */,
 			);
 			name = "Demo App";
@@ -270,6 +273,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C6131BB41D30429E002F27F3 /* PrimaryTransitionTargetViewController.swift in Sources */,
+				D2C07C7C2129BC8B00ED38D7 /* CustomMaskExample.swift in Sources */,
 				C6DF73D51D2DE2B500735EBC /* PrimaryContentViewController.swift in Sources */,
 				C6DF73EA1D2DFE7F00735EBC /* DrawerContentViewController.swift in Sources */,
 				C6DF73D31D2DE2B500735EBC /* AppDelegate.swift in Sources */,

--- a/Pulley/CustomMaskExample.swift
+++ b/Pulley/CustomMaskExample.swift
@@ -1,0 +1,77 @@
+//
+//  CustomMaskExample.swift
+//  Pulley
+//
+//  Created by Connor Power on 19.08.18.
+//  Copyright © 2018 52inc. All rights reserved.
+//
+
+import UIKit
+
+struct CustomMaskExample {
+
+    // MARK: - Constants
+
+    private struct Constants {
+        static let cornerRadius: CGFloat = 8.0
+        static let cutoutDistanceFromEdge: CGFloat = 32.0
+        static let cutoutRadius: CGFloat = 8.0
+    }
+
+    // MARK: - Functions
+
+    func customMask(for bounds: CGRect) -> UIBezierPath {
+        let maxX = bounds.maxX
+        let maxY = bounds.maxY
+
+        let path = UIBezierPath()
+        path.move(to: CGPoint(x: 0, y: maxY))
+
+        // Left hand edge
+        path.addLine(to: CGPoint(x: 0, y: Constants.cornerRadius))
+
+        // Top left rounded corner
+        path.addArc(withCenter: CGPoint(x: Constants.cornerRadius, y: Constants.cornerRadius),
+                    radius: Constants.cornerRadius,
+                    startAngle: CGFloat.pi,
+                    endAngle: 1.5 * CGFloat.pi,
+                    clockwise: true)
+
+        // Top edge left cutout section
+        path.addLine(to: CGPoint(x: Constants.cutoutDistanceFromEdge - Constants.cutoutRadius, y: 0))
+        path.addArc(withCenter: CGPoint(x: Constants.cutoutDistanceFromEdge, y: 0),
+                    radius: Constants.cutoutRadius,
+                    startAngle: CGFloat.pi,
+                    endAngle: 2.0 * CGFloat.pi,
+                    clockwise: false)
+        path.addLine(to: CGPoint(x: Constants.cutoutDistanceFromEdge + Constants.cutoutRadius, y: 0))
+
+        // Top edge right cutout section
+        path.addLine(to: CGPoint(x: maxX - Constants.cutoutDistanceFromEdge - Constants.cutoutRadius, y: 0))
+        path.addArc(withCenter: CGPoint(x: maxX - Constants.cutoutDistanceFromEdge, y: 0),
+                    radius: Constants.cutoutRadius,
+                    startAngle: CGFloat.pi,
+                    endAngle: 2.0 * CGFloat.pi,
+                    clockwise: false)
+        path.addLine(to: CGPoint(x: maxX - Constants.cutoutDistanceFromEdge + Constants.cutoutRadius, y: 0))
+        path.addLine(to: CGPoint(x: maxX - Constants.cornerRadius, y: 0))
+
+        // Top right rounded corner
+        path.addArc(withCenter: CGPoint(x: maxX - Constants.cornerRadius, y: Constants.cornerRadius),
+                    radius: Constants.cornerRadius,
+                    startAngle: 1.5 * CGFloat.pi,
+                    endAngle: 2.0 * CGFloat.pi,
+                    clockwise: true)
+
+        // Right hand edge
+        path.addLine(to: CGPoint(x: maxX, y: maxY))
+
+        // Bottom edge
+        path.addLine(to: CGPoint(x: 0, y: maxY))
+        path.close()
+        path.fill()
+
+        return path
+    }
+
+}

--- a/Pulley/DrawerContentViewController.swift
+++ b/Pulley/DrawerContentViewController.swift
@@ -11,6 +11,9 @@ import Pulley
 
 class DrawerContentViewController: UIViewController {
 
+    // Pulley can apply a custom mask to the panel drawer. This variable toggles an example.
+    private var shouldDisplayCustomMaskExample = false
+
     @IBOutlet var tableView: UITableView!
     @IBOutlet var searchBar: UISearchBar!
     @IBOutlet var gripperView: UIView!
@@ -48,6 +51,16 @@ class DrawerContentViewController: UIViewController {
         {
             let feedbackGenerator = UISelectionFeedbackGenerator()
             self.pulleyViewController?.feedbackGenerator = feedbackGenerator
+        }
+    }
+
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+
+        if shouldDisplayCustomMaskExample {
+            let maskLayer = CAShapeLayer()
+            maskLayer.path = CustomMaskExample().customMask(for: view.bounds).cgPath
+            view.layer.mask = maskLayer
         }
     }
     

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -277,7 +277,6 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
             
             if let drawerBackgroundVisualEffectView = drawerBackgroundVisualEffectView, self.isViewLoaded
             {
-                maskDrawerVisualEffectView()
                 drawerScrollView.insertSubview(drawerBackgroundVisualEffectView, aboveSubview: drawerShadowView)
                 drawerBackgroundVisualEffectView.clipsToBounds = true
                 drawerBackgroundVisualEffectView.layer.cornerRadius = drawerCornerRadius
@@ -1105,6 +1104,8 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         cardMaskLayer.fillColor = UIColor.white.cgColor
         cardMaskLayer.backgroundColor = UIColor.clear.cgColor
         drawerContentContainer.layer.mask = cardMaskLayer
+
+        maskDrawerVisualEffectView()
         
         if !isAnimatingDrawerPosition || borderPath.boundingBox.height < drawerShadowView.layer.shadowPath?.boundingBox.height ?? 0.0
         {

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -53,7 +53,6 @@ import UIKit
      *  Return the support drawer positions for your drawer.
      */
     @objc optional func supportedDrawerPositions() -> [PulleyPosition]
-
 }
 
 /**
@@ -847,7 +846,7 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         
         drawerContentContainer.transform = drawerScrollView.transform
         drawerShadowView.transform = drawerScrollView.transform
-
+        
         maskDrawerVisualEffectView()
         maskBackgroundDimmingView()
         setDrawerPosition(position: drawerPosition, animated: false)
@@ -900,7 +899,7 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         
         return drawerStops
     }
-
+    
     private func maskDrawerVisualEffectView() {
         if let drawerBackgroundVisualEffectView = drawerBackgroundVisualEffectView,
             let path = (drawerContentViewController.view.layer.mask as? CAShapeLayer)?.path {
@@ -915,6 +914,7 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
      Mask backgroundDimmingView layer to avoid drawer background beeing darkened.
      */
     private func maskBackgroundDimmingView() {
+        
         let cutoutHeight = 2 * drawerCornerRadius
         let maskHeight = backgroundDimmingView.bounds.size.height - cutoutHeight - drawerScrollView.contentSize.height
 
@@ -934,15 +934,15 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         }
 
         let maskLayer = CAShapeLayer()
-
+        
         // Invert mask to cut away the bottom part of the dimming view
         path.append(UIBezierPath(rect: backgroundDimmingView.bounds))
         maskLayer.fillRule = kCAFillRuleEvenOdd
-
+        
         maskLayer.path = path.cgPath
         backgroundDimmingView.layer.mask = maskLayer
     }
-
+    
     open func prepareFeedbackGenerator() {
         
         if #available(iOS 10.0, *) {
@@ -1334,7 +1334,7 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
             return PulleyPosition.all
         }
     }
-
+    
     open func drawerPositionDidChange(drawer: PulleyViewController, bottomSafeArea: CGFloat) {
         if let drawerVCCompliant = drawerContentViewController as? PulleyDrawerViewControllerDelegate {
             drawerVCCompliant.drawerPositionDidChange?(drawer: drawer, bottomSafeArea: bottomSafeArea)

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -876,6 +876,7 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         
         drawerContentContainer.transform = drawerScrollView.transform
         drawerShadowView.transform = drawerScrollView.transform
+        drawerBackgroundVisualEffectView?.transform = drawerScrollView.transform
         
         let lowestStop = getStopList().min() ?? 0
         


### PR DESCRIPTION
### Introduction

This pull request introduces non-API breaking support for custom drawer shapes supported through use of standard UIKit properties.

This may or may not be something which the maintainers wish to introduce into the main Pulley repo. Since we've managed to introduce this support in a non-intrusive, non-API breaking manner, I figured it worthwhile to submit a pull request.

### Use Case

Custom drawer shapes (i.e. for breakout elements) are currently unsupported by Pulley due to the manner in which the background UIEffectView and background dimming shadow are generated. Pulley currently only takes into account only rounded corners. An example of such a UI which is currently unsupported is shown below.

<img width="200" alt="masked pulley drawer" src="https://user-images.githubusercontent.com/779056/42381086-5d7e49bc-8130-11e8-9017-0ed5d93591a8.png">

### Proposed Change

Pulley could allow for custom masks which ultimately support any simple contiguous shape for the drawers.

### Proposed API

The proposed API involves applying any custom CALayer mask used by the `drawerContentViewController`'s view. I.e. if `drawerContentViewController.view.layer.mask != nil` then apply this mask also to both the dimming background view and the background UIEffectView.

Why this approach versus an additional `PulleyDrawerViewControllerDelegate` method? A custom mask is "power-user" feature which would be used in relatively few cases. Adding an additional delegate method would raise the complexity of the current public API for little benefit.

It could be reasonably expected that if the `drawerContentViewController` has a custom mask, that this custom mask is also appropriate for the drawer itself.