### PR TITLE
Fix a bug where the drawer distance delegate method would initially be the incorrect distance

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -877,6 +877,12 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         drawerContentContainer.transform = drawerScrollView.transform
         drawerShadowView.transform = drawerScrollView.transform
         
+        let lowestStop = getStopList().min() ?? 0
+        
+        delegate?.drawerChangedDistanceFromBottom?(drawer: self, distance: drawerScrollView.contentOffset.y + lowestStop, bottomSafeArea: pulleySafeAreaInsets.bottom)
+        (drawerContentViewController as? PulleyDrawerViewControllerDelegate)?.drawerChangedDistanceFromBottom?(drawer: self, distance: drawerScrollView.contentOffset.y + lowestStop, bottomSafeArea: pulleySafeAreaInsets.bottom)
+        (primaryContentViewController as? PulleyPrimaryContentControllerDelegate)?.drawerChangedDistanceFromBottom?(drawer: self, distance: drawerScrollView.contentOffset.y + lowestStop, bottomSafeArea: pulleySafeAreaInsets.bottom)
+        
         maskBackgroundDimmingView()
         setDrawerPosition(position: drawerPosition, animated: false)
     }
@@ -1600,4 +1606,3 @@ extension PulleyViewController: UIScrollViewDelegate {
         }
     }
 }
-


### PR DESCRIPTION
If you notice in the demo app, initially the temperature controls aren't showing up because the  drawerChangedDistanceFromBottom delegate method would provide a distance of 0 and therefore the constraints would position the temperature controls incorrectly. This PR aims to fix that issue.

Addresses issue #230.