### PR TITLE
Support transparency for primary content container

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -603,7 +603,8 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         
         return height
     }
-        
+
+    open var primaryContentShouldBeTransparent: Bool = false
     
     /**
      Initialize the drawer controller programmtically.
@@ -696,9 +697,9 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         
         drawerScrollView.addSubview(drawerContentContainer)
         
-        primaryContentContainer.backgroundColor = UIColor.white
+        primaryContentContainer.backgroundColor = primaryContentShouldBeTransparent ? UIColor.clear : UIColor.white
         
-        self.view.backgroundColor = UIColor.white
+        self.view.backgroundColor = primaryContentShouldBeTransparent ? UIColor.clear : UIColor.white
         
         self.view.addSubview(primaryContentContainer)
         self.view.addSubview(backgroundDimmingView)


### PR DESCRIPTION
Added support for subclasses of `PulleyViewController` to make the `primaryContentContainer` background and the main view to `UIColor.clear`.

This allows the `PulleyViewController`'s drawer to be presented on top of another `UIViewController` using the `overCurrentContext` or `overFullscreen` modal presentation style, without blocking the view of the presenting `UIViewController`.