### PR TITLE
*Crashes* Make sure that feedback generator is being called on main thread

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -1022,12 +1022,13 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
     open func triggerFeedbackGenerator() {
         
         if #available(iOS 10.0, *) {
-            
-            prepareFeedbackGenerator()
-            
-            (feedbackGenerator as? UIImpactFeedbackGenerator)?.impactOccurred()
-            (feedbackGenerator as? UISelectionFeedbackGenerator)?.selectionChanged()
-            (feedbackGenerator as? UINotificationFeedbackGenerator)?.notificationOccurred(.success)
+            DispatchQueue.main.async {
+                prepareFeedbackGenerator()
+                
+                (feedbackGenerator as? UIImpactFeedbackGenerator)?.impactOccurred()
+                (feedbackGenerator as? UISelectionFeedbackGenerator)?.selectionChanged()
+                (feedbackGenerator as? UINotificationFeedbackGenerator)?.notificationOccurred(.success)
+            }
         }
     }
     


### PR DESCRIPTION
I've been seeming to get a lot of crashes related to `-[_UIFeedbackEngine _deactivate]`, and I was thinking it may be due to not being on the main thread: https://stackoverflow.com/questions/40273911/uifeedback-haptic-engine-called-more-times-than-was-activated.