### PR TITLE
Make rawValue public

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -90,10 +90,15 @@ public typealias PulleyAnimationCompletionBlock = ((_ finished: Bool) -> Void)
         .closed
     ]
     
-    let rawValue: Int
+    public let rawValue: Int
     
-    init(rawValue: Int) {
-        self.rawValue = rawValue
+    public init(rawValue: Int) {
+        if rawValue < 0 || rawValue > 3 {
+            print("PulleyViewController: \(rawValue) is not supported. You have to use one of the predefined values in PulleyPosition. Defaulting to `collapsed`.")
+            self.rawValue = 0
+        } else {
+            self.rawValue = rawValue
+        }
     }
     
     /// Return one of the defined positions for the given string.
@@ -127,29 +132,12 @@ public typealias PulleyAnimationCompletionBlock = ((_ finished: Bool) -> Void)
         }
     }
 
-    /// Returns a string representation of the given position. Useful if you want to store the position.
-    ///
-    /// - Parameter position: One of the four `PulleyPosition` instances.
-    /// - Returns: A string representation of `PulleyPosition`. Can be used via `positionFor(:string)` to obtain the actual position.
-    public static func stringFor(position: PulleyPosition) -> String {
-
-        switch position {
-
-        case .collapsed:
-            return "collapsed"
-
-        case .partiallyRevealed:
-            return "partiallyrevealed"
-
-        case .open:
-            return "open"
-
-        case .closed:
-            return "closed"
-
-        default:
-            fatalError("Custom instances are not supported.")
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let position = object as? PulleyPosition else {
+            return false
         }
+
+        return self.rawValue == position.rawValue
     }
 }
 

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -94,7 +94,7 @@ public typealias PulleyAnimationCompletionBlock = ((_ finished: Bool) -> Void)
     
     public init(rawValue: Int) {
         if rawValue < 0 || rawValue > 3 {
-            print("PulleyViewController: \(rawValue) is not supported. You have to use one of the predefined values in PulleyPosition. Defaulting to `collapsed`.")
+            print("PulleyViewController: A raw value of \(rawValue) is not supported. You have to use one of the predefined values in PulleyPosition. Defaulting to `collapsed`.")
             self.rawValue = 0
         } else {
             self.rawValue = rawValue

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -96,6 +96,10 @@ public typealias PulleyAnimationCompletionBlock = ((_ finished: Bool) -> Void)
         self.rawValue = rawValue
     }
     
+    /// Return one of the defined positions for the given string.
+    ///
+    /// - Parameter string: The string, preferably obtained by `stringFor(position:)`
+    /// - Returns: The `PulleyPosition` or `.collapsed` if the string didn't match.
     public static func positionFor(string: String?) -> PulleyPosition {
         
         guard let positionString = string?.lowercased() else {
@@ -120,6 +124,31 @@ public typealias PulleyAnimationCompletionBlock = ((_ finished: Bool) -> Void)
         default:
             print("PulleyViewController: Position for string '\(positionString)' not found. Available values are: collapsed, partiallyRevealed, open, and closed. Defaulting to collapsed.")
             return .collapsed
+        }
+    }
+
+    /// Returns a string representation of the given position. Useful if you want to store the position.
+    ///
+    /// - Parameter position: One of the four `PulleyPosition` instances.
+    /// - Returns: A string representation of `PulleyPosition`. Can be used via `positionFor(:string)` to obtain the actual position.
+    public static func stringFor(position: PulleyPosition) -> String {
+
+        switch position {
+
+        case .collapsed:
+            return "collapsed"
+
+        case .partiallyRevealed:
+            return "partiallyrevealed"
+
+        case .open:
+            return "open"
+
+        case .closed:
+            return "closed"
+
+        default:
+            fatalError("Custom instances are not supported.")
         }
     }
 }


### PR DESCRIPTION
Outdated, see https://github.com/52inc/Pulley/pull/305#issuecomment-458943544

---

I needed to store the current drawer position to restore it on the next launch. Initially I implemented `Codable` for `PulleyPosition` but then realised that the code requires the position to be one of the predefined instances and not a custom one created be a `Decoder`.

Since there was already a method to get one of those instance from a given `String` I added another method to convert a given position to that `String`. Now you can store it (e.g. in `UserDefaults`) and safely restore the position on the next launch.

Example: 

```swift
extension UserDefaults {
	var drawerPosition: PulleyPosition {
		get {
			guard let positionString = string(forKey: #function) else {
				return .partiallyRevealed
			}

			return PulleyPosition.positionFor(string: positionString)
		}

		set {
			let positionString = PulleyPosition.stringFor(position: newValue)
			set(positionString, forKey: #function)
		}
	}
}
```