### PR TITLE
Fix/mask 

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -998,7 +998,13 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         let cutoutHeight = 2 * drawerCornerRadius
         let maskHeight = backgroundDimmingView.bounds.size.height - cutoutHeight - drawerScrollView.contentSize.height
         let borderPath = drawerMaskingPath(byRoundingCorners: [.topLeft, .topRight])
-        borderPath.apply(CGAffineTransform(translationX: 0.0, y: maskHeight))
+        
+        // This applys the boarder path transform to the minimum x of the content container for iPhone X size devices
+        if let frame = drawerContentContainer.superview?.convert(drawerContentContainer.frame, to: nil) {
+            borderPath.apply(CGAffineTransform(translationX: frame.minX, y: maskHeight))
+        } else  {
+            borderPath.apply(CGAffineTransform(translationX: 0.0, y: maskHeight))
+        }
         let maskLayer = CAShapeLayer()
 
         // Invert mask to cut away the bottom part of the dimming view

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -1000,7 +1000,7 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         let borderPath = drawerMaskingPath(byRoundingCorners: [.topLeft, .topRight])
         
         // This applys the boarder path transform to the minimum x of the content container for iPhone X size devices
-        if let frame = drawerContentContainer.superview?.convert(drawerContentContainer.frame, to: nil) {
+        if let frame = drawerContentContainer.superview?.convert(drawerContentContainer.frame, to: self.view) {
             borderPath.apply(CGAffineTransform(translationX: frame.minX, y: maskHeight))
         } else  {
             borderPath.apply(CGAffineTransform(translationX: 0.0, y: maskHeight))


### PR DESCRIPTION
I have tested this on iPhone X, Xs Max, 5s, and iPad and the behavior looks correct. This PR still under testing to confirm it plays well with safe area and non-safe area devices, and confirm that the mask does not break for any of the inset controls. This PR addressed issue #284.