### PR TITLE
Enable .panel mode for iPhone SE

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -799,7 +799,7 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         let safeAreaRightInset = pulleySafeAreaInsets.right
 
         
-        let displayModeForCurrentLayout: PulleyDisplayMode = displayMode != .automatic ? displayMode : ((self.view.bounds.width >= 600.0 || self.traitCollection.horizontalSizeClass == .regular) ? .panel : .drawer)
+        let displayModeForCurrentLayout: PulleyDisplayMode = displayMode != .automatic ? displayMode : ((self.traitCollection.verticalSizeClass == .compact || self.view.bounds.width >= 600.0 || self.traitCollection.horizontalSizeClass == .regular) ? .panel : .drawer)
         
         currentDisplayMode = displayModeForCurrentLayout
         


### PR DESCRIPTION
Adding .compact to displayModeForCurrentLayout to enable .panel mode to iPhone SE.

Currently, if you rotate an iPhone SE to landscape mode, the panel takes a lot of space from the already small screen of the device, covering other buttons of the application.