### PR TITLE
Allow delegate to customise dimmer cutout height without custom CAShape

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -50,6 +50,11 @@ import UIKit
     @objc optional func partialRevealDrawerHeight(bottomSafeArea: CGFloat) -> CGFloat
     
     /**
+     *  Provide the drawer dimmerCutout offset for Pulley.
+    */
+    @objc optional func drawerDimmerCutoutOffset() -> CGFloat
+
+    /**
      *  Return the support drawer positions for your drawer.
      */
     @objc optional func supportedDrawerPositions() -> [PulleyPosition]
@@ -177,6 +182,7 @@ public enum PulleySnapMode {
 
 private let kPulleyDefaultCollapsedHeight: CGFloat = 68.0
 private let kPulleyDefaultPartialRevealHeight: CGFloat = 264.0
+private let kPulleyDefaultDimmerCutoutOffset: CGFloat = 0.0
 
 open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDelegate {
     
@@ -1012,7 +1018,9 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
      Mask backgroundDimmingView layer to avoid drawer background beeing darkened.
      */
     private func maskBackgroundDimmingView() {
-        let cutoutHeight = 2 * drawerCornerRadius
+        let userAdjustedCutout = (drawerContentViewController as? PulleyDrawerViewControllerDelegate)?.drawerDimmerCutoutOffset?()
+                                 ?? kPulleyDefaultDimmerCutoutOffset
+        let cutoutHeight = (2 * drawerCornerRadius) + userAdjustedCutout
         let maskHeight = backgroundDimmingView.bounds.size.height - cutoutHeight - drawerScrollView.contentSize.height
         let borderPath = drawerMaskingPath(byRoundingCorners: [.topLeft, .topRight])
         


### PR DESCRIPTION
I had case when Drawer provided puller tip at the top of drawer body with transparent background. In result I get something like this:

![IMG_4969](https://user-images.githubusercontent.com/24235281/68384437-49828480-0160-11ea-9d5f-2de006eadde3.jpg)

I know there is an option to make custom shape, but I thought that delegating that stuff to a drawer could be a nice idea.

![IMG_4968](https://user-images.githubusercontent.com/24235281/68384504-6919ad00-0160-11ea-9e4a-cce704004c85.jpg)

