### PR TITLE
Fix Layout Glitch on allowsUserDrawerPositionChange Changing Value

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -946,6 +946,7 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         guard isViewLoaded else {
             return
         }
+        
         let contentOffset = drawerScrollView.contentOffset
         drawerScrollView.isScrollEnabled = allowsUserDrawerPositionChange && supportedPositions.count > 1
         drawerScrollView.setContentOffset(contentOffset, animated: false)

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -946,8 +946,9 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         guard isViewLoaded else {
             return
         }
-        
+        let contentOffset = drawerScrollView.contentOffset
         drawerScrollView.isScrollEnabled = allowsUserDrawerPositionChange && supportedPositions.count > 1
+        drawerScrollView.setContentOffset(contentOffset, animated: false)
     }
 
      func getStopList() -> [CGFloat] {


### PR DESCRIPTION
- Download the sample app, open the drawer to the fully open position, and then change the value of `allowsUserDrawerPositionChange` to false. The drawer will glitch 20pts downward. 
- For some reason changing the value of `drawerScrollView.isScrollEnabled` is messing up the content offset, so I simply saved the content offset before the `isScrollEnabled` change and reset it to the same value after without animation, and this fixed the visual bug.