### PR TITLE
Modernize auto layout embedding

### DIFF
--- a/PulleyLib/UIView+constrainToParent.swift
+++ b/PulleyLib/UIView+constrainToParent.swift
@@ -15,12 +15,17 @@ extension UIView {
     
     func constrainToParent(insets: UIEdgeInsets) {
         guard let parent = superview else { return }
-        
         translatesAutoresizingMaskIntoConstraints = false
-        let metrics: [String : Any] = ["left" : insets.left, "right" : insets.right, "top" : insets.top, "bottom" : insets.bottom]
-        
-        parent.addConstraints(["H:|-(left)-[view]-(right)-|", "V:|-(top)-[view]-(bottom)-|"].flatMap {
-            NSLayoutConstraint.constraints(withVisualFormat: $0, metrics: metrics, views: ["view": self])
-        })
+
+		topAnchor.constraint(equalTo: parent.topAnchor, constant: insets.top).isActive = true
+		leadingAnchor.constraint(equalTo: parent.leadingAnchor, constant: insets.left).isActive = true
+
+		let bc = bottomAnchor.constraint(equalTo: parent.bottomAnchor, constant: -insets.bottom)
+		bc.priority = .init(999)
+		bc.isActive = true
+
+		let tc = trailingAnchor.constraint(equalTo: parent.trailingAnchor, constant: -insets.right)
+		tc.priority = .init(999)
+		tc.isActive = true
     }
 }


### PR DESCRIPTION
Use NSLayoutAnchors instead of visual format.

Make sure bottom and trailing constraints are of priority 999 – this prevents AL exceptions thrown into Xcode console when you try to animate some embedded content from 0 to something. 
(just make sure that clip-to-bounds is ON)

With original code, if you actually try to apply insets to constraintToParent() you get this in the console:

```
[LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
	(Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints) 
(
    "<NSAutoresizingMaskLayoutConstraint:0x600001c1c1e0 h=--& v=--& UIView:0x7fdad7006790.height == 0   (active)>",
    "<NSLayoutConstraint:0x600001c65360 V:|-(20)-[UIView:0x7fdad7202f30]   (active, names: '|':UIView:0x7fdad7006790 )>",
    "<NSLayoutConstraint:0x600001c653b0 V:[UIView:0x7fdad7202f30]-(40)-|   (active, names: '|':UIView:0x7fdad7006790 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x600001c653b0 V:[UIView:0x7fdad7202f30]-(40)-|   (active, names: '|':UIView:0x7fdad7006790 )>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
```

