### PR TITLE
Fix the bouncy drawer bug on iPad and Mac

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -1363,7 +1363,10 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
                     (drawer.drawerContentViewController as? PulleyDrawerViewControllerDelegate)?.drawerPositionDidChange?(drawer: drawer, bottomSafeArea: self?.pulleySafeAreaInsets.bottom ?? 0.0)
                     (drawer.primaryContentViewController as? PulleyPrimaryContentControllerDelegate)?.drawerPositionDidChange?(drawer: drawer, bottomSafeArea: self?.pulleySafeAreaInsets.bottom ?? 0.0)
                     
-                    drawer.view.layoutIfNeeded()
+                    // Fix the bouncy drawer bug on iPad and Mac
+                    if UIDevice.current.userInterfaceIdiom == .phone {
+                        drawer.view.layoutIfNeeded()
+                    }
                 }
 
                 }, completion: { [weak self] (completed) in


### PR DESCRIPTION
# Description

I'm currently using Pulley for a project that contains a UISplitViewController, I found out that when I open a view controller that has Pulley in it, it does that bouncy effect. I tried to fix the issue and it worked for me, so I thought I should open a PR. :)

Here's a short video for the bug: https://youtu.be/h_ztzbAuBjw

Fixes: The bouncy drawer bug on iPad and Mac

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you performed to verify your changes. Provide instructions so we can reproduce. Please provide details on how you tested supported versions of iOS and Xcode. Please make sure you have tested on all device size classes and orientations. Please also list any relevant details for your test configuration

- [x] Test macOS BigSur 11.0.1
- [x] Test iOS 14
- [ ] Test iOS 13
- [ ] Test iOS 12
- [ ] Test iOS 11
- [ ] Test iOS 10
- [ ] Test iOS 9

**Test Configuration**
- Xcode Versions: 12.2
- Simulators:  iPad Pro 9.7 (14.2),
- Physical Hardware: iPhone X (4.2), MacBook Pro 16" (macOS BigSur 11.0.1)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My code does not break backwards compatibility with earlier versions of PulleyLib
- [x] My code is fully functional with all supported device sizes and orientations
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that my code does not break the behavior of the Sample/Demo app
- [x] My changes generate no new warnings
- [x] I have tested and can prove my fix is effective or that my feature works
