### PR TITLE
fix: panel mode closed state has visible drawer part

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -1274,7 +1274,7 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
 
         let lowestStop = getStopList().min() ?? 0
         
-        drawerContentContainer.frame = CGRect(x: 0.0, y: drawerScrollView.bounds.height - lowestStop , width: drawerScrollView.bounds.width, height: drawerScrollView.contentOffset.y + lowestStop + bounceOverflowMargin)
+        drawerContentContainer.frame = CGRect(x: 0.0, y: drawerScrollView.bounds.height - lowestStop , width: drawerScrollView.bounds.width, height: drawerScrollView.contentOffset.y + lowestStop)
         drawerBackgroundVisualEffectView?.frame = drawerContentContainer.frame
         drawerShadowView.frame = drawerContentContainer.frame
         


### PR DESCRIPTION
# Description

When using pulley in panel display mode, in closed position the drawer is still visible because of the **bounceOverflowMargin** that is added to drawer's height in panel mode.

By removing **bounceOverflowMargin** from the height calculation in **syncDrawerContentViewSizeToMatchScrollPositionForSideDisplayMode**
This is no longer an issue

Fixes # (issue)
https://github.com/52inc/Pulley/issues/409

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

To reproduce the issue call **setDrawerPosition** with **.closed**  in panel mode.
Expected result - no visible drawer
Actual result - part of the drawer is visible with height equal to **bounceOverflowMargin**

With the fix only panel mode is affected and the drawer is hidden as expected in **.closed** position

- [ ] Test iOS 14
- [ ] Test iOS 13

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code does not break backwards compatibility with earlier versions of PulleyLib
- [ ] My code is fully functional with all supported device sizes and orientations
- [ ] I have performed a self-review of my own code
- [ ] I have checked that my code does not break the behavior of the Sample/Demo app
- [ ] My changes generate no new warnings
- [ ] I have tested and can prove my fix is effective or that my feature works
