### PR TITLE
Use animationDuration for transition animation duration

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -1419,7 +1419,7 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         
         if animated
         {
-            UIView.transition(with: primaryContentContainer, duration: 0.5, options: .transitionCrossDissolve, animations: { [weak self] () -> Void in
+            UIView.transition(with: primaryContentContainer, duration: animationDuration, options: .transitionCrossDissolve, animations: { [weak self] () -> Void in
                 
                 self?.primaryContentViewController = controller
                 
@@ -1462,7 +1462,7 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         
         if animated
         {
-            UIView.transition(with: drawerContentContainer, duration: 0.5, options: .transitionCrossDissolve, animations: { [weak self] () -> Void in
+            UIView.transition(with: drawerContentContainer, duration: animationDuration, options: .transitionCrossDissolve, animations: { [weak self] () -> Void in
                 
                 self?.drawerContentViewController = controller
                 self?.setDrawerPosition(position: position ?? (self?.drawerPosition ?? .collapsed), animated: false)


### PR DESCRIPTION
# Description

This uses the already existing `animationDuration` to animate when a primary or drawer view controller changes instead of hardcoding it to 0.5.

This alters the behavior, as the default `animationDuration` is set to `0.3`, but the hardcoded value was set to `0.5`. As this is only a cosmetic change, I would argue that it does not break previous behavior.

If you would like to introduce a new property for it instead of reusing the (then poorly named) `animationDuration`, I would be happy to get name suggestions.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My code does not break backwards compatibility with earlier versions of PulleyLib
- [x] My code is fully functional with all supported device sizes and orientations
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that my code does not break the behavior of the Sample/Demo app
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have tested and can prove my fix is effective or that my feature works
