### PR TITLE
Fix hide bounce overflow on closed

### DIFF
--- a/Pulley/Main.storyboard
+++ b/Pulley/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eGL-tC-8gT">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eGL-tC-8gT">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -447,9 +447,6 @@
         </scene>
     </scenes>
     <resources>
-        <systemColor name="lightTextColor">
-            <color white="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="lightTextColor">
             <color white="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -1273,8 +1273,8 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         }
 
         let lowestStop = getStopList().min() ?? 0
-        
-        drawerContentContainer.frame = CGRect(x: 0.0, y: drawerScrollView.bounds.height - lowestStop , width: drawerScrollView.bounds.width, height: drawerScrollView.contentOffset.y + lowestStop + bounceOverflowMargin)
+         
+        drawerContentContainer.frame = CGRect(x: 0.0, y: drawerScrollView.bounds.height - lowestStop , width: drawerScrollView.bounds.width, height: drawerScrollView.contentOffset.y + lowestStop + (drawerPosition != .closed ? bounceOverflowMargin : 0))
         drawerBackgroundVisualEffectView?.frame = drawerContentContainer.frame
         drawerShadowView.frame = drawerContentContainer.frame
         


### PR DESCRIPTION
# Description

This is a modification of [this](https://github.com/52inc/Pulley/pull/410) pull request to fix issue #409. That only removes the bounceOverflowMargin when the drawer is `.closed`.

Fixes #409

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you performed to verify your changes. Provide instructions so we can reproduce. Please provide details on how you tested supported versions of iOS and Xcode. Please make sure you have tested on all device size classes and orientations. Please also list any relevant details for your test configuration

- [x] Test iOS 14
- [ ] Test iOS 13
- [ ] Test iOS 12
- [ ] Test iOS 11
- [ ] Test iOS 10
- [ ] Test iOS 9

**Test Configuration**
- Xcode Versions: [e.g. 12.x, 11.x, 10.x, 9.x]
- Simulators: [e.g. iPad Pro (14.x), iPhone SE (12.x)]
- Physical Hardware: [e.g. iPad Pro (14.x), iPhone SE (12.x)]

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My code does not break backwards compatibility with earlier versions of PulleyLib
- [x] My code is fully functional with all supported device sizes and orientations
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that my code does not break the behavior of the Sample/Demo app
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested and can prove my fix is effective or that my feature works
