### PR TITLE
Fix Xcode 14 compiler warning

### DIFF
--- a/PulleyLib/PulleyPassthroughScrollView.swift
+++ b/PulleyLib/PulleyPassthroughScrollView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol PulleyPassthroughScrollViewDelegate: class {
+protocol PulleyPassthroughScrollViewDelegate: AnyObject {
     
     func shouldTouchPassthroughScrollView(scrollView: PulleyPassthroughScrollView, point: CGPoint) -> Bool
     func viewToReceiveTouch(scrollView: PulleyPassthroughScrollView, point: CGPoint) -> UIView

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 /**
  *  The base delegate protocol for Pulley delegates.
  */
-@objc public protocol PulleyDelegate: class {
+@objc public protocol PulleyDelegate: AnyObject {
     
     /** This is called after size changes, so if you care about the bottomSafeArea property for custom UI layout, you can use this value.
      * NOTE: It's not called *during* the transition between sizes (such as in an animation coordinator), but rather after the resize is complete.


### PR DESCRIPTION
# Description

protocol `class` has been deprecated and replaced with `AnyObject`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Successful compilation with the following

- [x] Test iOS 14
- [x] Test iOS 13
- [x] Test iOS 12

**Test Configuration**
- Xcode Versions: [13.3 & 14.0]

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My code does not break backwards compatibility with earlier versions of PulleyLib
- [x] My code is fully functional with all supported device sizes and orientations
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that my code does not break the behavior of the Sample/Demo app
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have tested and can prove my fix is effective or that my feature works
