### PR TITLE
Fix black horizontal line on top of pulley on Mac Catalyst

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -713,6 +713,9 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         } else if currentDisplayMode == .drawer {
             height -= drawerTopInset
         }
+#if targetEnvironment(macCatalyst)
+        height = roundToEven(height)
+#endif
         
         return height
     }
@@ -926,14 +929,22 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
             
             if supportedPositions.contains(.open)
             {
+                var topPos = drawerTopInset + safeAreaTopInset
+#if targetEnvironment(macCatalyst)
+                topPos = roundToEven(topPos)
+#endif
                 // Layout scrollview
-                drawerScrollView.frame = CGRect(x: adjustedLeftSafeArea, y: drawerTopInset + safeAreaTopInset, width: self.view.bounds.width - adjustedLeftSafeArea - adjustedRightSafeArea, height: heightOfOpenDrawer)
+                drawerScrollView.frame = CGRect(x: adjustedLeftSafeArea, y: topPos, width: self.view.bounds.width - adjustedLeftSafeArea - adjustedRightSafeArea, height: heightOfOpenDrawer)
             }
             else
             {
                 // Layout scrollview
                 let adjustedTopInset: CGFloat = getStopList().max() ?? 0.0
-                drawerScrollView.frame = CGRect(x: adjustedLeftSafeArea, y: self.view.bounds.height - adjustedTopInset, width: self.view.bounds.width - adjustedLeftSafeArea - adjustedRightSafeArea, height: adjustedTopInset)
+                var topPos = self.view.bounds.height - adjustedTopInset
+#if targetEnvironment(macCatalyst)
+                topPos = roundToEven(topPos)
+#endif
+                drawerScrollView.frame = CGRect(x: adjustedLeftSafeArea, y: topPos, width: self.view.bounds.width - adjustedLeftSafeArea - adjustedRightSafeArea, height: adjustedTopInset)
             }
             
             drawerScrollView.addSubview(drawerShadowView)
@@ -1009,7 +1020,9 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
                 yOrigin = (panelCornerPlacement == .bottomLeft || panelCornerPlacement == .bottomRight) ? (panelInsets.top + safeAreaTopInset) : (panelInsets.top + safeAreaTopInset + bounceOverflowMargin)
                 
             }
-            
+#if targetEnvironment(macCatalyst)
+            yOrigin = roundToEven(yOrigin)
+#endif
             if supportedPositions.contains(.open)
             {
                 // Layout scrollview
@@ -1091,7 +1104,11 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
             collapsedHeight = drawerVCCompliant.collapsedDrawerHeight?(bottomSafeArea: pulleySafeAreaInsets.bottom) ?? kPulleyDefaultCollapsedHeight
             partialRevealHeight = drawerVCCompliant.partialRevealDrawerHeight?(bottomSafeArea: pulleySafeAreaInsets.bottom) ?? kPulleyDefaultPartialRevealHeight
         }
-        
+#if targetEnvironment(macCatalyst)
+         collapsedHeight = roundToEven(collapsedHeight)
+         partialRevealHeight = roundToEven(partialRevealHeight)
+#endif
+         
         if supportedPositions.contains(.collapsed)
         {
             drawerStops.append(collapsedHeight)
@@ -1104,7 +1121,11 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         
         if supportedPositions.contains(.open)
         {
-            drawerStops.append((self.view.bounds.size.height - drawerTopInset - pulleySafeAreaInsets.top))
+            var value = (self.view.bounds.size.height - drawerTopInset - pulleySafeAreaInsets.top)
+#if targetEnvironment(macCatalyst)
+            value = roundToEven(value)
+#endif
+            drawerStops.append(value)
         }
         
         return drawerStops
@@ -1622,6 +1643,13 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
             drawerVCCompliant.drawerChangedDistanceFromBottom?(drawer: drawer, distance: distance, bottomSafeArea: bottomSafeArea)
         }
     }
+    
+#if targetEnvironment(macCatalyst)
+    func roundToEven(_ number: CGFloat) -> CGFloat {
+        let rounded = number.rounded()
+        return rounded.remainder(dividingBy: 2) == 0 ? rounded : rounded + 1
+    }
+#endif
 }
 
 extension PulleyViewController: PulleyPassthroughScrollViewDelegate {


### PR DESCRIPTION
The height and position of the pulley is rounded to nearest even number on Mac Catalyst. This will fix the horizontal ghost line.

# Description

The line may disappear if the window is resized. We have the same issue on the toolbar in the view behind the pulley. Now it behaves like removing the pulley from the view. 

Fixes #424 Strange lines on mac catalyst 16

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I have tested the change using our app on the following devices. The change is effective for target platform mac catalyst only. 

- [x] Test Mac OS 15.1.1 (Mac Catalyst) 
- [x] Test iOS 18
- [x] Test iOS 17

**Test Configuration**
- Xcode Versions: 16.1
- Simulators: -
- Physical Hardware: Mac Book Pro (M1), iPad Pro 10.5" (iOS 17.7.2), iPhone 12 Pro (iOS 18.1.1)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code does not break backwards compatibility with earlier versions of PulleyLib
- [ ] My code is fully functional with all supported device sizes and orientations
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked that my code does not break the behavior of the Sample/Demo app
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have tested and can prove my fix is effective or that my feature works
